### PR TITLE
Add record identifier to 'Invalid date' message in JsonConverter

### DIFF
--- a/src/main/java/eu/ehri/project/search/converter/impl/JsonConverter.java
+++ b/src/main/java/eu/ehri/project/search/converter/impl/JsonConverter.java
@@ -203,7 +203,7 @@ public class JsonConverter implements Converter<JsonNode> {
                         data.put(key, fixDates((String) data.get(key)));
                     } catch (IllegalArgumentException e) {
                         data.remove(key);
-                        System.err.println("Invalid date: " + data.get(key));
+                        System.err.println("Invalid date: " + data.get(key) + " (in: " + data.get("id") + ")");
                     }
                 }
             }


### PR DESCRIPTION
It's useful to know what records have invalid dates, so that they may be corrected. This commit adds the identifier of the record to the 'log' message.
