### PR TITLE
Lots of improvements for library use

### DIFF
--- a/index-data-converter/pom.xml
+++ b/index-data-converter/pom.xml
@@ -3,21 +3,23 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>index-data-converter</artifactId>
 
-    <!-- Assembly plugin used to generate a jar with all dependencies -->
     <build>
         <plugins>
+            <!-- Assembly plugin used to generate a jar with all dependencies -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             <mainClass>eu.ehri.project.indexing.IndexHelper</mainClass>
                         </manifest>
                     </archive>

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/IndexHelper.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/IndexHelper.java
@@ -6,16 +6,25 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import eu.ehri.project.indexing.converter.Converter;
 import eu.ehri.project.indexing.converter.impl.JsonConverter;
-import eu.ehri.project.indexing.converter.impl.MultiConverter;
 import eu.ehri.project.indexing.converter.impl.NoopConverter;
 import eu.ehri.project.indexing.index.Index;
 import eu.ehri.project.indexing.index.impl.SolrIndex;
 import eu.ehri.project.indexing.sink.Sink;
-import eu.ehri.project.indexing.sink.impl.*;
+import eu.ehri.project.indexing.sink.impl.CallbackSink;
+import eu.ehri.project.indexing.sink.impl.IndexJsonSink;
+import eu.ehri.project.indexing.sink.impl.OutputStreamJsonSink;
 import eu.ehri.project.indexing.source.Source;
-import eu.ehri.project.indexing.source.impl.*;
+import eu.ehri.project.indexing.source.impl.FileJsonSource;
+import eu.ehri.project.indexing.source.impl.InputStreamJsonSource;
+import eu.ehri.project.indexing.source.impl.WebJsonSource;
 import eu.ehri.project.indexing.utils.Stats;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
@@ -33,10 +42,15 @@ import java.util.Properties;
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class IndexHelper {
+public class IndexHelper extends Pipeline<JsonNode, JsonNode> {
 
-    public static final String PROGRAM_NAME = "index-helper";
-    public static final String VERSION_NUMBER = "1.0.1";
+    /**
+     * Default service end points.
+     * <p/>
+     * TODO: Store these in a properties file?
+     */
+    private static final String DEFAULT_SOLR_URL = "http://localhost:8983/solr/portal";
+    private static final String DEFAULT_EHRI_URL = "http://localhost:7474/ehri";
 
     enum ErrCodes {
         BAD_SOURCE_ERR(3),
@@ -56,96 +70,8 @@ public class IndexHelper {
         }
     }
 
-    /**
-     * Default service end points.
-     * <p/>
-     * TODO: Store these in a properties file?
-     */
-    private static final String DEFAULT_SOLR_URL = "http://localhost:8983/solr/portal";
-    private static final String DEFAULT_EHRI_URL = "http://localhost:7474/ehri";
-
-    private final Source<JsonNode> source;
-    private final Sink<JsonNode> writer;
-    private final Converter<JsonNode> converter;
-
-    /**
-     * Builder for an Indexer. More options to come.
-     */
-    public static class Builder {
-        private final List<Source<JsonNode>> sources = Lists.newArrayList();
-        private final List<Sink<JsonNode>> writers = Lists.newArrayList();
-        private final List<Converter<JsonNode>> converters = Lists.newArrayList();
-
-        public Builder addSink(Sink<JsonNode> writer) {
-            writers.add(writer);
-            return this;
-        }
-
-        private Sink<JsonNode> getSink() {
-            if (writers.size() > 1) {
-                return new MultiSink<>(writers);
-            } else if (writers.size() == 1) {
-                return writers.get(0);
-            } else {
-                return new NoopSink<>();
-            }
-        }
-
-        public Source<JsonNode> getSource() {
-            if (sources.size() > 1) {
-                return new MultiSource<>(sources);
-            } else if (sources.size() == 1) {
-                return sources.get(0);
-            } else {
-                return new NoopSource<>();
-            }
-        }
-
-        public Builder addSource(Source<JsonNode> source) {
-            this.sources.add(source);
-            return this;
-        }
-
-        public Converter<JsonNode> getConverter() {
-            if (converters.size() > 1) {
-                return new MultiConverter<>(converters);
-            } else if (converters.size() == 1) {
-                return converters.get(0);
-            } else {
-                return new NoopConverter<>();
-            }
-        }
-
-        public Builder addConverter(Converter<JsonNode> converter) {
-            this.converters.add(converter);
-            return this;
-        }
-
-        public IndexHelper build() {
-            return new IndexHelper(this);
-        }
-    }
-
-    private IndexHelper(Builder builder) {
-        this.writer = builder.getSink();
-        this.source = builder.getSource();
-        this.converter = builder.getConverter();
-    }
-
-    /**
-     * Perform the actual actions.
-     */
-    public void iterate() throws Source.SourceException, Sink.SinkException, Converter.ConverterException {
-        try {
-            for (JsonNode item : source.getIterable()) {
-                for (JsonNode out : converter.convert(item)) {
-                    writer.write(out);
-                }
-            }
-        } finally {
-            source.finish();
-            writer.finish();
-        }
+    private IndexHelper(Builder<JsonNode, JsonNode> builder) {
+        super(builder);
     }
 
     /**
@@ -194,6 +120,7 @@ public class IndexHelper {
     }
 
 
+    @SuppressWarnings("static-access")
     public static void main(String[] args) throws IOException, ParseException {
 
         // Long opts
@@ -255,12 +182,15 @@ public class IndexHelper {
         CommandLineParser parser = new GnuParser();
         CommandLine cmd = parser.parse(options, args);
 
+        final String toolName = IndexHelper.class.getPackage().getImplementationTitle();
+        final String toolVersion = IndexHelper.class.getPackage().getImplementationVersion();
+
         if (cmd.hasOption(VERSION)) {
-            System.out.println(PROGRAM_NAME + " " + VERSION_NUMBER);
+            System.out.println(toolName + " " + toolVersion);
             System.exit(0);
         }
 
-        String usage = PROGRAM_NAME + " [OPTIONS] <spec> ... <specN>";
+        String usage = toolName + " [OPTIONS] <spec> ... <specN>";
         String help = "\n" +
                 "Each <spec> should consist of:\n" +
                 "   * an item type (all items of that type)\n" +
@@ -280,7 +210,7 @@ public class IndexHelper {
         String solrUrl = cmd.getOptionValue(SOLR_URL, DEFAULT_SOLR_URL);
         Properties restHeaders = cmd.getOptionProperties(HEADERS);
 
-        IndexHelper.Builder builder = new IndexHelper.Builder();
+        IndexHelper.Builder<JsonNode, JsonNode> builder = new IndexHelper.Builder<>();
 
         // Initialize the index...
         Index index = new SolrIndex(solrUrl);
@@ -302,9 +232,9 @@ public class IndexHelper {
 
         // Determine if we want to convert the data or print the incoming
         // JSON as-is...
-        if (!cmd.hasOption(NO_CONVERT)) {
-            builder.addConverter(new JsonConverter());
-        }
+        builder.addConverter(cmd.hasOption(NO_CONVERT)
+                ? new NoopConverter<JsonNode>()
+                : new JsonConverter());
 
         // See if we want to print stats... if so create a callback sink
         // to count the individual items and optionally print them...
@@ -372,7 +302,7 @@ public class IndexHelper {
             }
 
             // Now do the main indexing tasks
-            builder.build().iterate();
+            builder.build().run();
         } catch (Source.SourceException e) {
             System.err.println(e.getMessage());
             System.exit(ErrCodes.BAD_SOURCE_ERR.getCode());

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/Pipeline.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/Pipeline.java
@@ -1,0 +1,111 @@
+package eu.ehri.project.indexing;
+
+import com.google.common.collect.Lists;
+import eu.ehri.project.indexing.converter.Converter;
+import eu.ehri.project.indexing.converter.impl.MultiConverter;
+import eu.ehri.project.indexing.sink.Sink;
+import eu.ehri.project.indexing.sink.impl.MultiSink;
+import eu.ehri.project.indexing.sink.impl.NoopSink;
+import eu.ehri.project.indexing.source.Source;
+import eu.ehri.project.indexing.source.impl.MultiSource;
+import eu.ehri.project.indexing.source.impl.NoopSource;
+
+import java.util.List;
+
+/**
+ * A class to orchestrate flow from sources, converters,
+ * and sinks.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class Pipeline<S, E> {
+
+    protected final Source<? extends S> source;
+    protected final Sink<? super E> writer;
+    protected final Converter<S, ? extends E> converter;
+
+    /**
+     * Pipeline builder.
+     */
+    public static class Builder<S, E> {
+        private final List<Source<? extends S>> sources = Lists.newArrayList();
+        private final List<Converter<S, ? extends E>> converters = Lists.newArrayList();
+        private final List<Sink<? super E>> writers = Lists.newArrayList();
+
+        public Builder<S, E> addSink(Sink<E> writer) {
+            writers.add(writer);
+            return this;
+        }
+
+        public Builder<S, E> addSource(Source<S> source) {
+            this.sources.add(source);
+            return this;
+        }
+
+        public Builder<S, E> addConverter(Converter<S, ? extends E> converter) {
+            this.converters.add(converter);
+            return this;
+        }
+
+        private Sink<? super E> getSink() {
+            if (writers.size() > 1) {
+                return new MultiSink<>(writers);
+            } else if (writers.size() == 1) {
+                return writers.get(0);
+            } else {
+                return new NoopSink<>();
+            }
+        }
+
+        private Source<? extends S> getSource() {
+            if (sources.size() > 1) {
+                return new MultiSource<>(sources);
+            } else if (sources.size() == 1) {
+                return sources.get(0);
+            } else {
+                return new NoopSource<>();
+            }
+        }
+
+        private Converter<S, ? extends E> getConverter() {
+            if (converters.size() > 1) {
+                return new MultiConverter<>(converters);
+            } else if (converters.size() == 1) {
+                return converters.get(0);
+            } else {
+                throw new IllegalStateException("No converters defined " +
+                        "for mapping sources to sinks");
+            }
+        }
+
+        public Pipeline<S, E> build() {
+            return new Pipeline<>(this);
+        }
+    }
+
+    protected Pipeline(Builder<S, E> builder) {
+        this.writer = builder.getSink();
+        this.source = builder.getSource();
+        this.converter = builder.getConverter();
+    }
+
+    /**
+     * Initiate the pipeline.
+     *
+     * @throws Source.SourceException
+     * @throws Sink.SinkException
+     * @throws Converter.ConverterException
+     */
+    public void run() throws Source.SourceException, Sink.SinkException, Converter.ConverterException {
+        try {
+            for (S item : source.iterable()) {
+                for (E out : converter.convert(item)) {
+                    writer.write(out);
+                }
+            }
+        } finally {
+            source.close();
+            writer.close();
+        }
+    }
+}

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/Converter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/Converter.java
@@ -3,7 +3,7 @@ package eu.ehri.project.indexing.converter;
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public interface Converter<T> {
+public interface Converter<S, E> {
 
     class ConverterException extends Exception {
 
@@ -12,5 +12,5 @@ public interface Converter<T> {
         }
     }
 
-    Iterable<T> convert(T t) throws ConverterException;
+    Iterable<E> convert(S t) throws ConverterException;
 }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
@@ -23,7 +23,7 @@ import java.util.*;
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class JsonConverter implements Converter<JsonNode> {
+public class JsonConverter implements Converter<JsonNode, JsonNode> {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonConverter.class);
 

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/MultiConverter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/MultiConverter.java
@@ -10,18 +10,18 @@ import java.util.List;
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class MultiConverter<T> implements Converter<T> {
-    private final List<Converter<T>> converters;
+public class MultiConverter<S, E> implements Converter<S, E> {
+    private final List<Converter<S, ? extends E>> converters;
 
-    public MultiConverter(List<Converter<T>> converters) {
+    public MultiConverter(List<Converter<S, ? extends E>> converters) {
         this.converters = Lists.newArrayList(converters);
     }
 
     @Override
-    public Iterable<T> convert(T t) throws ConverterException {
-        List<T> temp = Lists.newArrayList();
-        for (Converter<T> converter : converters) {
-            for (T out : converter.convert(t)) {
+    public Iterable<E> convert(S t) throws ConverterException {
+        List<E> temp = Lists.newArrayList();
+        for (Converter<S, ? extends E> converter : converters) {
+            for (E out : converter.convert(t)) {
                 temp.add(out);
             }
         }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/NoopConverter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/NoopConverter.java
@@ -6,7 +6,7 @@ import eu.ehri.project.indexing.converter.Converter;
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class NoopConverter<T> implements Converter<T> {
+public class NoopConverter<T> implements Converter<T, T> {
     @Override
     public Iterable<T> convert(T t) throws ConverterException {
         //noinspection unchecked

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/Sink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/Sink.java
@@ -3,7 +3,7 @@ package eu.ehri.project.indexing.sink;
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public interface Sink<T> {
+public interface Sink<T> extends AutoCloseable {
 
     class SinkException extends Exception {
         public SinkException(String message, Exception e) {
@@ -13,5 +13,5 @@ public interface Sink<T> {
 
     void write(T t) throws SinkException;
 
-    void finish() throws SinkException;
+    void close() throws SinkException;
 }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/BufferSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/BufferSink.java
@@ -1,0 +1,26 @@
+package eu.ehri.project.indexing.sink.impl;
+
+import eu.ehri.project.indexing.sink.Sink;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class BufferSink<T> implements Sink<T> {
+    private final Collection<? super T> buffer;
+
+    public BufferSink(Collection<? super T> buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public void write(T t) throws SinkException {
+        buffer.add(t);
+    }
+
+    @Override
+    public void close() throws SinkException {
+    }
+}

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/CallbackSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/CallbackSink.java
@@ -6,7 +6,7 @@ import eu.ehri.project.indexing.sink.Sink;
 import java.util.List;
 
 /**
- * Run a function on write and finish.
+ * Run a function on write and close.
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
@@ -34,7 +34,7 @@ public class CallbackSink<T> implements Sink<T> {
         }
     }
 
-    public void finish() {
+    public void close() {
         for (Callback<T> cb : callbacks) {
             cb.finish();
         }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/IndexJsonSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/IndexJsonSink.java
@@ -49,8 +49,8 @@ public class IndexJsonSink implements Sink<JsonNode> {
         npw.write(node);
     }
 
-    public void finish() throws SinkException {
-        npw.finish();
+    public void close() throws SinkException {
+        npw.close();
         final AtomicBoolean done = new AtomicBoolean(false);
 
         new Thread() {

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/MultiSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/MultiSink.java
@@ -10,7 +10,7 @@ import java.util.List;
  *
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public class MultiSink<T, W extends Sink<T>> implements Sink<T> {
+public class MultiSink<T, W extends Sink<? super T>> implements Sink<T> {
 
     private final List<W> writers;
 
@@ -24,9 +24,9 @@ public class MultiSink<T, W extends Sink<T>> implements Sink<T> {
         }
     }
 
-    public void finish() throws SinkException {
+    public void close() throws SinkException {
         for (W writer : writers) {
-            writer.finish();
+            writer.close();
         }
     }
 }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/NoopSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/NoopSink.java
@@ -15,6 +15,6 @@ public class NoopSink<T> implements Sink<T> {
     public void write(T t) {
     }
 
-    public void finish() {
+    public void close() {
     }
 }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/OutputStreamJsonSink.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/sink/impl/OutputStreamJsonSink.java
@@ -49,7 +49,7 @@ public class OutputStreamJsonSink implements Sink<JsonNode> {
 
     }
 
-    public void finish() throws SinkException {
+    public void close() throws SinkException {
         if (generator != null) {
             try {
                 generator.writeEndArray();

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/source/Source.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/source/Source.java
@@ -3,7 +3,7 @@ package eu.ehri.project.indexing.source;
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */
-public interface Source<T> {
+public interface Source<T> extends AutoCloseable {
     class SourceException extends Exception {
         public SourceException(String message) {
             super(message);
@@ -14,9 +14,9 @@ public interface Source<T> {
         }
     }
 
-    Iterable<T> getIterable() throws SourceException;
+    Iterable<T> iterable() throws SourceException;
 
     boolean isFinished();
 
-    void finish() throws SourceException;
+    void close() throws SourceException;
 }

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/FileJsonSource.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/FileJsonSource.java
@@ -23,10 +23,10 @@ public class FileJsonSource implements Source<JsonNode> {
         this.fileName = fileName;
     }
 
-    public void finish() throws SourceException {
+    public void close() throws SourceException {
         finished = true;
         if (ios != null) {
-            ios.finish();
+            ios.close();
         }
         try {
             if (fis != null) {
@@ -38,7 +38,7 @@ public class FileJsonSource implements Source<JsonNode> {
     }
 
     @Override
-    public Iterable<JsonNode> getIterable() throws SourceException {
+    public Iterable<JsonNode> iterable() throws SourceException {
         try {
             File file = new File(fileName);
             if (!(file.exists() && file.isFile())) {
@@ -50,7 +50,7 @@ public class FileJsonSource implements Source<JsonNode> {
         } catch (FileNotFoundException e) {
             throw new SourceException("File not found: " + fileName, e);
         }
-        return ios.getIterable();
+        return ios.iterable();
     }
 
     @Override

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/InputStreamJsonSource.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/InputStreamJsonSource.java
@@ -26,7 +26,7 @@ public class InputStreamJsonSource implements Source<JsonNode> {
         this.ios = ios;
     }
 
-    public void finish() throws SourceException {
+    public void close() throws SourceException {
         finished = true;
         if (jsonParser != null) {
             try {
@@ -38,7 +38,7 @@ public class InputStreamJsonSource implements Source<JsonNode> {
     }
 
     @Override
-    public Iterable<JsonNode> getIterable() throws SourceException {
+    public Iterable<JsonNode> iterable() throws SourceException {
         try {
             jsonParser = jsonFactory.createParser(ios);
             JsonToken firstToken = jsonParser.nextValue();

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/NoopSource.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/NoopSource.java
@@ -12,11 +12,11 @@ import java.util.Iterator;
  */
 public class NoopSource<T> implements Source<T> {
     @Override
-    public void finish() throws SourceException {
+    public void close() throws SourceException {
     }
 
     @Override
-    public Iterable<T> getIterable() throws SourceException {
+    public Iterable<T> iterable() throws SourceException {
         return new Iterable<T>() {
             @Override
             public Iterator<T> iterator() {

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/WebJsonSource.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/source/impl/WebJsonSource.java
@@ -30,10 +30,10 @@ public class WebJsonSource implements Source<JsonNode> {
         this.headers = headers;
     }
 
-    public void finish() throws SourceException {
+    public void close() throws SourceException {
         if (!finished) {
             if (ios != null) {
-                ios.finish();
+                ios.close();
                 ios = null;
             }
             if (response != null) {
@@ -45,7 +45,7 @@ public class WebJsonSource implements Source<JsonNode> {
     }
 
     @Override
-    public Iterable<JsonNode> getIterable() throws SourceException {
+    public Iterable<JsonNode> iterable() throws SourceException {
         response = getResponse();
         checkResponse(response);
         InputStream entityInputStream = response.getEntityInputStream();
@@ -53,7 +53,7 @@ public class WebJsonSource implements Source<JsonNode> {
             throw new SourceException("Entity stream is null for url: " + url);
         }
         ios = new InputStreamJsonSource(entityInputStream);
-        return ios.getIterable();
+        return ios.iterable();
     }
 
     @Override

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/utils/Stats.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/utils/Stats.java
@@ -22,4 +22,8 @@ public class Stats {
         pw.println("Items indexed: " + itemCount);
         pw.println("Items per second: " + (itemCount / duration));
     }
+
+    public int getCount() {
+        return itemCount;
+    }
 }

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/PipelineTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/PipelineTest.java
@@ -1,0 +1,77 @@
+package eu.ehri.project.indexing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import eu.ehri.project.indexing.sink.impl.BufferSink;
+import eu.ehri.project.indexing.sink.impl.CallbackSink;
+import eu.ehri.project.indexing.source.impl.InputStreamJsonSource;
+import eu.ehri.project.indexing.test.JsonToXml;
+import eu.ehri.project.indexing.test.StringSource;
+import eu.ehri.project.indexing.test.StringToInteger;
+import eu.ehri.project.indexing.utils.Stats;
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class PipelineTest {
+
+    @Test
+    public void testPipeline1() throws Exception {
+        List<Number> out = Lists.newArrayList();
+
+        new Pipeline.Builder<String, Number>()
+                .addSource(new StringSource(Lists.newArrayList("1", "2", "3")))
+                .addConverter(new StringToInteger())
+                .addSink(new BufferSink<>(out))
+                .build()
+                .run();
+
+        assertEquals(Lists.newArrayList(1, 2, 3), out);
+    }
+
+    @Test
+    public void testPipeline2() throws Exception {
+        String json = "[{\"foo\": \"bar\"}, {\"bar\": \"baz\"}]";
+        InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+        final List<String> outText = Lists.newArrayList();
+        final Stats stats = new Stats();
+
+        new Pipeline.Builder<JsonNode, Node>()
+                .addSource(new InputStreamJsonSource(stream))
+                .addConverter(new JsonToXml("test"))
+                .addSink(new CallbackSink<>(new CallbackSink.Callback<Node>() {
+                    @Override
+                    public void call(Node node) {
+                        stats.incrementCount();
+                        outText.add(JsonToXml.nodeToString(node));
+                    }
+
+                    @Override
+                    public void finish() {
+                    }
+                }))
+                .build()
+                .run();
+
+        assertEquals(2, stats.getCount());
+        assertEquals(2, outText.size());
+        assertEquals("<test>\n<foo>bar</foo>\n</test>\n", outText.get(0));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPipelineMissingConverted() throws Exception {
+        new Pipeline.Builder<String, Number>()
+                .addSource(new StringSource(Lists.newArrayList("1", "2", "3")))
+                .addSink(new BufferSink<>(Lists.<Number>newArrayList()))
+                .build();
+    }
+}

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/converter/impl/JsonConverterTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/converter/impl/JsonConverterTest.java
@@ -91,9 +91,9 @@ public class JsonConverterTest {
             InputStream stream = getClass().getClassLoader().getResourceAsStream(testResource);
             Source<JsonNode> source = new InputStreamJsonSource(stream);
             try {
-                inputs.add(Iterables.get(source.getIterable(), 0));
+                inputs.add(Iterables.get(source.iterable(), 0));
             } finally {
-                source.finish();
+                source.close();
                 stream.close();
             }
         }

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/sink/impl/IndexJsonSinkTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/sink/impl/IndexJsonSinkTest.java
@@ -14,7 +14,7 @@ public class IndexJsonSinkTest {
         IndexJsonSink sink = new IndexJsonSink(dummy);
         sink.write(new TextNode("foo"));
         sink.write(new TextNode("bar"));
-        sink.finish();
+        sink.close();
         assertEquals("[\"foo\",\"bar\"]", dummy.getBuffer());
     }
 }

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/FileJsonSourceTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/FileJsonSourceTest.java
@@ -26,15 +26,15 @@ public class FileJsonSourceTest {
     public void testGetIterable() throws Exception {
         FileJsonSource source = new FileJsonSource(getResourcePath());
         try {
-            assertEquals(1, Iterables.size(source.getIterable()));
+            assertEquals(1, Iterables.size(source.iterable()));
         } finally {
-            source.finish();
+            source.close();
         }
     }
 
     @Test(expected = Source.SourceException.class)
     public void testGetIterableWithBadSource() throws Exception {
         FileJsonSource source = new FileJsonSource("DOES_NOT_EXIST");
-        assertEquals(1, Iterables.size(source.getIterable()));
+        assertEquals(1, Iterables.size(source.iterable()));
     }
 }

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/InputStreamJsonSourceTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/InputStreamJsonSourceTest.java
@@ -59,9 +59,9 @@ public class InputStreamJsonSourceTest {
     private List<JsonNode> listFromStream(InputStream stream) throws Exception {
         Source<JsonNode> source = new InputStreamJsonSource(stream);
         try {
-            return Lists.newArrayList(source.getIterable());
+            return Lists.newArrayList(source.iterable());
         } finally {
-            source.finish();
+            source.close();
             stream.close();
             assertTrue(source.isFinished());
         }

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/MultiSourceTest.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/source/impl/MultiSourceTest.java
@@ -26,7 +26,7 @@ public class MultiSourceTest {
         }
 
         @Override
-        public Iterable<String> getIterable() throws SourceException {
+        public Iterable<String> iterable() throws SourceException {
             return data;
         }
 
@@ -36,7 +36,7 @@ public class MultiSourceTest {
         }
 
         @Override
-        public void finish() throws SourceException {
+        public void close() throws SourceException {
             finished = true;
         }
     }
@@ -47,9 +47,9 @@ public class MultiSourceTest {
         TestSource src2 = new TestSource("d", "e", "f");
         TestSource src3 = new TestSource("g", "h", "i");
 
-        MultiSource<String> multiSource = new MultiSource<>(
-                Lists.<Source<String>>newArrayList(src1, src2, src3));
-        Iterable<String> iterable = multiSource.getIterable();
+        MultiSource<String, TestSource> multiSource = new MultiSource<>(
+                Lists.newArrayList(src1, src2, src3));
+        Iterable<String> iterable = multiSource.iterable();
         Iterator<String> iterator = iterable.iterator();
         assertEquals("a", iterator.next());
         assertEquals("b", iterator.next());

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/test/JsonToXml.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/test/JsonToXml.java
@@ -1,0 +1,79 @@
+package eu.ehri.project.indexing.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import eu.ehri.project.indexing.converter.Converter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Test class for crude JSON-XML conversion.
+ *
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class JsonToXml implements Converter<JsonNode, Node> {
+
+    private static final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    private static final Document document;
+    static {
+        try {
+            document = factory.newDocumentBuilder().newDocument();
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final String eleName;
+
+    public JsonToXml(String name) {
+        eleName = name;
+    }
+
+    @Override
+    public Iterable<Node> convert(JsonNode t) throws ConverterException {
+        if (!t.isObject()) {
+            return Lists.newArrayList();
+        }
+
+        Node node = document.createElement(eleName);
+        Iterator<Map.Entry<String, JsonNode>> fields = t.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> kv = fields.next();
+            Node child = document.createElement(kv.getKey());
+            node.appendChild(child);
+            if (kv.getValue().isValueNode()) {
+                child.appendChild(document.createTextNode(kv.getValue().asText()));
+            } else {
+                for (Node c : convert(kv.getValue())) {
+                    child.appendChild(c);
+                }
+            }
+        }
+        return Lists.newArrayList(node);
+    }
+
+    public static String nodeToString(Node node) {
+        try {
+            StringWriter sw = new StringWriter();
+            Transformer t = TransformerFactory.newInstance().newTransformer();
+            t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            t.setOutputProperty(OutputKeys.INDENT, "yes");
+            t.transform(new DOMSource(node), new StreamResult(sw));
+            return sw.toString();
+        } catch (TransformerException te) {
+            throw new RuntimeException("nodeToString Transformer Exception");
+        }
+    }
+}

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/test/StringSource.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/test/StringSource.java
@@ -1,0 +1,31 @@
+package eu.ehri.project.indexing.test;
+
+import eu.ehri.project.indexing.source.Source;
+
+import java.util.List;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class StringSource implements Source<String> {
+
+    private final List<String> strings;
+
+    public StringSource(List<String> strings) {
+        this.strings = strings;
+    }
+
+    @Override
+    public Iterable<String> iterable() throws SourceException {
+        return strings;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+
+    @Override
+    public void close() throws SourceException {
+    }
+}

--- a/index-data-converter/src/test/java/eu/ehri/project/indexing/test/StringToInteger.java
+++ b/index-data-converter/src/test/java/eu/ehri/project/indexing/test/StringToInteger.java
@@ -1,0 +1,14 @@
+package eu.ehri.project.indexing.test;
+
+import com.google.common.collect.Lists;
+import eu.ehri.project.indexing.converter.Converter;
+
+/**
+ * @author Mike Bryant (http://github.com/mikesname)
+ */
+public class StringToInteger implements Converter<String, Integer> {
+    @Override
+    public Iterable<Integer> convert(String t) throws ConverterException {
+        return Lists.newArrayList(Integer.valueOf(t));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>search-tools</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <modules>
         <module>solr-config</module>
         <module>index-data-converter</module>
@@ -67,6 +67,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>

--- a/solr-config/pom.xml
+++ b/solr-config/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Extracted the orchestration logic into a separate Pipeline class
 - Use as a library more flexible with wildcard types
 - Converter types can now, sensibly, be different on input and output
 - The index helper now extends this with JsonNode as both start and
   end types
 - More tests for the overall flow
 - Get tool name and version from packaging metadata
 - Make source and sink implement AutoCloseable
 - Prevent commons-cli warnings
 - Bumped version