### PR TITLE
Various fixes, mostly to fix sorting behaviour.

### DIFF
--- a/index-data-converter/pom.xml
+++ b/index-data-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>search-tools</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <modules>
         <module>solr-config</module>
         <module>index-data-converter</module>

--- a/solr-config/pom.xml
+++ b/solr-config/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/solr-config/solr/portal/conf/schema.xml
+++ b/solr-config/solr/portal/conf/schema.xml
@@ -73,31 +73,13 @@
         <!-- Field type for sorting items. Removes all non-alphanumeric.
           Pinched from http://stackoverflow.com/a/3783380/285374
           with ASCIIFoldingFilterFactory substituted for ISOLatin1AccentFactory -->
-        <fieldType name="text_prefix" class="solr.TextField" positionIncrementGap="1" sortMissingLast="true">
-            <analyzer type="index">
+        <fieldType name="text_prefix" class="solr.TextField" sortMissingLast="true">
+            <analyzer>
                 <tokenizer class="solr.KeywordTokenizerFactory"/>
-                <filter class="solr.ASCIIFoldingFilterFactory"/>
-                <filter class="solr.LowerCaseFilterFactory"/>
-                <!-- Remove non alpha-numeric characters -->
-                <filter class="solr.PatternReplaceFilterFactory" pattern="[^a-zA-Z0-9 ]" replacement="" replace="all"/>
-                <filter class="solr.TrimFilterFactory"/>
+                <filter class="solr.ICUFoldingFilterFactory"/>
                 <!-- Remove leading "the "-->
                 <filter class="solr.PatternReplaceFilterFactory" pattern="^the\s" replacement="" replace="all"/>
                 <filter class="solr.TrimFilterFactory"/>
-                <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="6"/>
-                <filter class="solr.ICUFoldingFilterFactory"/>
-            </analyzer>
-            <analyzer type="query">
-                <tokenizer class="solr.KeywordTokenizerFactory"/>
-                <filter class="solr.ASCIIFoldingFilterFactory"/>
-                <filter class="solr.LowerCaseFilterFactory"/>
-                <!-- Remove non alpha-numeric characters -->
-                <filter class="solr.PatternReplaceFilterFactory" pattern="[^a-zA-Z0-9 ]" replacement="" replace="all"/>
-                <filter class="solr.TrimFilterFactory"/>
-                <!-- Remove leading "the "-->
-                <filter class="solr.PatternReplaceFilterFactory" pattern="^the\s" replacement="" replace="all"/>
-                <filter class="solr.TrimFilterFactory"/>
-                <filter class="solr.ICUFoldingFilterFactory"/>
             </analyzer>
         </fieldType>
 


### PR DESCRIPTION
 - The text_prefix field was *completely* broken due to being ngram tokenized. Fix this and radically simplify how this is analyzed, preventing all unicode chars from being stripped.
 - Hack in Kosovo as a missing country code/name
 - Remove unnecessary constructor
 - Handle array values in char length estimation