### PR TITLE
Extract more info concerning link targets, inc. id, type, names.

### DIFF
--- a/index-data-converter/pom.xml
+++ b/index-data-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.5</version>
+        <version>1.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
@@ -305,6 +305,17 @@ public class JsonConverter implements Converter<JsonNode, JsonNode> {
         }
         data.put("charCount", charCount);
 
+        // HACK: Add a boolean for links with/without an external body
+        if (data.containsKey("linkBodyName")) {
+            data.put("hasBody", true);
+        }
+        if (data.containsKey("targetIds")) {
+            Object targets = data.get("targetIds");
+            if (targets instanceof List) {
+                data.put("targetCount", ((List) targets).size());
+            }
+        }
+
         return data;
     }
 

--- a/index-data-converter/src/main/resources/paths.properties
+++ b/index-data-converter/src/main/resources/paths.properties
@@ -73,11 +73,20 @@ groupName=relationships.belongsTo[*].data.name
 
 # Target items for annotations and links. These may
 # or may not have multiple descriptions
+targetIds=\
+  relationships.hasLinkTarget[*].id,\
+  relationships.annotates[*].id
+targetTypes=\
+  relationships.hasLinkTarget[*].type,\
+  relationships.annotates[*].type
 targets=\
   relationships.hasLinkTarget[*].relationships.describes[*].data.name,\
   relationships.hasLinkTarget[*].data.name,\
   relationships.annotates[*].relationships.describes[*].data.name,\
   relationships.annotates[*].data.name
+
+# Link external body (typically an access point)
+linkBodyName=relationships.hasLinkBody[*].data.name
 
 annotatorId=relationships.hasAnnotation[0].id
 annotatorName=relationships.hasAnnotation[0].data.name

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ehri-project</groupId>
     <artifactId>search-tools</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <modules>
         <module>solr-config</module>
         <module>index-data-converter</module>

--- a/solr-config/pom.xml
+++ b/solr-config/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>search-tools</artifactId>
         <groupId>ehri-project</groupId>
-        <version>1.1.5</version>
+        <version>1.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/solr-config/solr/portal/conf/schema.xml
+++ b/solr-config/solr/portal/conf/schema.xml
@@ -361,6 +361,9 @@
         <field name="targetNames" type="text_general" indexed="true" stored="false" multiValued="true"/>
         <field name="targetNames_ngram" type="text_general_edge_ngram" indexed="true" stored="false"
                multiValued="true"/>
+        <field name="targetIds" type="string" indexed="true" stored="true" multiValued="true"/>
+        <field name="targetTypes" type="string" indexed="true" stored="true" multiValued="true"/>
+        <field name="targetCount" type="int" indexed="true" stored="true" multiValued="false"/>
         <field name="addresses" type="text_general" indexed="true" stored="true" multiValued="true"/>
         <field name="priority" type="int" indexed="true" stored="true" multiValued="false"/>
         <field name="creationProcess" type="string" indexed="true" stored="true" multiValued="false" default="MANUAL"/>
@@ -372,6 +375,8 @@
         <field name="annotatorId" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="annotatorName" type="string" indexed="true" stored="false" multiValued="false"/>
         <field name="promotionScore" type="int" indexed="true" stored="true" multiValued="false" default="0"/>
+        <field name="linkBodyName" type="text_general" indexed="true" stored="false" multiValued="true"/>
+        <field name="hasBody" type="boolean" indexed="true" stored="true" multiValued="false" default="false"/>
         <field name="_version_" type="long" indexed="true" stored="true"/>
 
         <dynamicField name="*_i" type="int" indexed="true" stored="true"/>


### PR DESCRIPTION
Also added a boolean `hasBody` to discriminate access point links from free-floating ones.

Bumped version.