### PR TITLE
Make parse context non static, since it includes an LRU cache.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM dockerfile/java:oracle-java8
 ENV SOLR_VERSION 4.10.4
 ENV SOLR solr-$SOLR_VERSION
 ENV SOLR_MIRROR http://archive.apache.org/dist/lucene/solr
-ENV TOOL_VERSION 1.1.1-SNAPSHOT
+ENV TOOL_VERSION 1.1.6
 ENV PORT 8983
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
+++ b/index-data-converter/src/main/java/eu/ehri/project/indexing/converter/impl/JsonConverter.java
@@ -33,7 +33,7 @@ public class JsonConverter implements Converter<JsonNode, JsonNode> {
     /**
      * Json Parser
      */
-    public static final ParseContext parseContext = JsonPath.using(new JacksonJsonProvider());
+    private final ParseContext parseContext;
 
     /**
      * Keys which have types that require special handling.
@@ -83,6 +83,10 @@ public class JsonConverter implements Converter<JsonNode, JsonNode> {
         countryLookup = ImmutableMap.copyOf(countries);
     }
 
+    public JsonConverter() {
+        parseContext = JsonPath.using(new JacksonJsonProvider());
+    }
+
     /**
      * Convert a individual item into one or more output items
      *
@@ -113,7 +117,7 @@ public class JsonConverter implements Converter<JsonNode, JsonNode> {
      * @param item        The item's JSON node
      * @return A map of the extracted data
      */
-    private static Map<String, Object> getDescribedData(JsonNode description, JsonNode item) {
+    private Map<String, Object> getDescribedData(JsonNode description, JsonNode item) {
 
         // Tricky code alert!
         // Matching paths in the 'item' node overrides that of the description,
@@ -150,7 +154,7 @@ public class JsonConverter implements Converter<JsonNode, JsonNode> {
      * @param node The item's JSON node
      * @return A map of the extracted data
      */
-    private static Map<String, Object> getData(JsonNode node) {
+    private Map<String, Object> getData(JsonNode node) {
         Map<String, Object> data = Maps.newHashMap();
         ReadContext ctx = parseContext.parse(node.toString());
 


### PR DESCRIPTION
The `JsonConverter` was not thread safe due to this omission, which caused odd stuff to happen when used as a library.