### PR TITLE
Temporarily make int fields multi-valued as a workaround for Solr-7495.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <solr.version>6.1.0</solr.version>
+        <solr.version>6.2.0</solr.version>
     </properties>
 
     <issueManagement>

--- a/solr-config/core/conf/schema.xml
+++ b/solr-config/core/conf/schema.xml
@@ -298,7 +298,8 @@
         <field name="type" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
         <field name="itemId" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
         <field name="gid" type="long" indexed="true" stored="true" multiValued="false" required="false"/>
-        <field name="childCount" type="int" indexed="true" stored="true" default="0" multiValued="false" required="false"/>
+        <field name="childCount" type="int" indexed="true" stored="true" default="0" multiValued="true"
+               required="false"/>
         <field name="parentId" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="ancestorIds" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="dateStart" type="date" indexed="true" stored="true" multiValued="false"/>
@@ -335,7 +336,7 @@
         <field name="languageCode" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="countryCode" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="countryName" type="string" indexed="true" stored="true" multiValued="false"/>
-        <field name="depthOfDescription" type="int" indexed="true" stored="true" multiValued="false"/>
+        <field name="depthOfDescription" type="int" indexed="true" stored="true" multiValued="true"/>
         <field name="levelOfDescription" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="languageOfMaterial" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="typeOfEntity" type="string" indexed="true" stored="true" multiValued="false"/>
@@ -363,9 +364,9 @@
                multiValued="true"/>
         <field name="targetIds" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="targetTypes" type="string" indexed="true" stored="true" multiValued="true"/>
-        <field name="targetCount" type="int" indexed="true" stored="true" multiValued="false"/>
+        <field name="targetCount" type="int" indexed="true" stored="true" multiValued="true"/>
         <field name="addresses" type="text_general" indexed="true" stored="true" multiValued="true"/>
-        <field name="priority" type="int" indexed="true" stored="true" multiValued="false"/>
+        <field name="priority" type="int" indexed="true" stored="true" multiValued="true"/>
         <field name="creationProcess" type="string" indexed="true" stored="true" multiValued="false" default="MANUAL"/>
         <field name="charCount" type="int" indexed="true" stored="true" multiValued="false"/>
         <field name="latitude" type="double" indexed="true" stored="true" multiValued="false"/>
@@ -374,7 +375,7 @@
         <field name="isPromotable" type="boolean" indexed="true" stored="true" multiValued="false" default="false"/>
         <field name="annotatorId" type="string" indexed="true" stored="true" multiValued="false"/>
         <field name="annotatorName" type="string" indexed="true" stored="false" multiValued="false"/>
-        <field name="promotionScore" type="int" indexed="true" stored="true" multiValued="false" default="0"/>
+        <field name="promotionScore" type="int" indexed="true" stored="true" multiValued="true" default="0"/>
         <field name="linkBodyName" type="text_general" indexed="true" stored="false" multiValued="true"/>
         <field name="linkType" type="string" indexed="true" stored="true" multiValued="true"/>
         <field name="linkField" type="string" indexed="true" stored="true" multiValued="true"/>

--- a/solr-config/src/test/java/eu/ehri/project/solr/SearchTest.java
+++ b/solr-config/src/test/java/eu/ehri/project/solr/SearchTest.java
@@ -110,4 +110,19 @@ public class SearchTest extends AbstractSolrTest {
         with(json2)
                 .assertThat("$.grouped.itemId.matches", equalTo(18));
     }
+
+    @Test
+    public void testFacetOnIntValues() throws Exception {
+        // Test for SOLR-7495 bug which breaks faceting on non-multi-valued
+        // int fields. As a workaround the fields where made multi-valued.
+        // https://issues.apache.org/jira/browse/SOLR-7495
+        String json = runSearch("*", "fq", "priority:5", "facet.field", "priority", "rows", "0");
+        //System.out.println(json);
+        with(json)
+                .assertThat("$.grouped.itemId.matches", equalTo(221));
+
+        String json2 = runSearch("*", "fq", "promotionScore:1", "facet.field", "promotionScore", "rows", "0");
+        with(json2)
+                .assertThat("$.grouped.itemId.matches", equalTo(0));
+    }
 }


### PR DESCRIPTION
Exclude charCount since its used for sorted. This is all obviously very unpleasant - hopefully Solr will be fixed in the next version.

See: https://issues.apache.org/jira/browse/SOLR-7495